### PR TITLE
update method name for destroying active pane on quit

### DIFF
--- a/lib/atom-vim-colon-command-on-command-pallete.coffee
+++ b/lib/atom-vim-colon-command-on-command-pallete.coffee
@@ -34,11 +34,11 @@ module.exports =
     atom.workspace.getActiveTextEditor().save()
 
   quit: ->
-    atom.workspace.destroyActivePaneItemOrEmptyPane()
+    atom.workspace.destroyActivePaneItem()
 
   writeAndQuit: ->
     atom.workspace.getActiveTextEditor().save()
-    atom.workspace.destroyActivePaneItemOrEmptyPane()
+    atom.workspace.destroyActivePaneItem()
 
   openNewTab: ->
     atom.workspace.open()


### PR DESCRIPTION
Fix for https://github.com/takkjoga/atom-vim-colon-command-on-command-pallete/issues/2. `atom.workspace.destroyActivePaneItemOrEmptyPane()` has been removed from Atom 1.6. 
