### PR TITLE
Update keymap to vim-mode-plus as vim-mode has been deprecated

### DIFF
--- a/keymaps/atom-vim-colon-command-on-command-pallete.cson
+++ b/keymaps/atom-vim-colon-command-on-command-pallete.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
-'atom-text-editor.vim-mode:not(.insert-mode)':
+'atom-text-editor.vim-mode-plus:not(.insert-mode)':
   ':': 'command-palette:toggle'


### PR DESCRIPTION
Given people will be using vim-mode-plus instead of vim-mode going forward it would good for this package to support vim-mode-plus by default.